### PR TITLE
prefix 'v' to the tag_name

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -144,7 +144,7 @@ const orderCommits = (commits, tags, exists) => {
     const changelog = createChangelog(grouped, commits, changeTypes)
 
     // Upload changelog to GitHub Releases
-    createRelease(tags[0].version, changelog, exists)
+    createRelease(`v${tags[0].version}`, changelog, exists)
   })
 }
 


### PR DESCRIPTION
Current behavior doesn't include the 'v' prefix, as seen here:

![image](https://cloud.githubusercontent.com/assets/6847633/21670877/8f886668-d2cc-11e6-8e67-803d4d27afb4.png)
