### PR TITLE
remove duplicate credit names

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -7,7 +7,7 @@ const pickCommit = require('./pick-commit')
 
 module.exports = async (types, commits, changeTypes) => {
   let text = ''
-  let credits = []
+  const credits = new Set()
 
   for (const type in types) {
     if (!{}.hasOwnProperty.call(types, type)) {
@@ -39,7 +39,9 @@ module.exports = async (types, commits, changeTypes) => {
       }
 
       if (changeDetails.credits && changeDetails.credits.length > 0) {
-        credits = credits.concat(changeDetails.credits)
+        changeDetails.credits.forEach(item => {
+          credits.add(item)
+        })
       }
 
       if (change === lastChange) {
@@ -48,25 +50,27 @@ module.exports = async (types, commits, changeTypes) => {
     }
   }
 
-  if (credits.length > 0) {
+  if (credits.size > 0) {
     text += '\n'
     text += '### Credits \n\n'
     text += 'Huge thanks to '
 
-    const lastCredit = credits.length - 1
-
     // GitHub links usernames if prefixed with @
-    for (const credit of credits) {
+    let index = 1
+    credits.forEach(credit => {
       text += `@${credit}`
 
-      const index = credits.indexOf(credit)
-      const penultimate = index === (lastCredit - 1)
-      const notLast = index !== lastCredit
+      const penultimate = index === (credits.size - 1)
+      const notLast = index !== credits.size
 
-      if (notLast) {
-        text += penultimate ? ' and ' : ', '
+      if (penultimate) {
+        text += ' and '
+      } else if (notLast) {
+        text += ', '
       }
-    }
+
+      index += 1
+    })
 
     text += ' for their help!'
     text += '\n'


### PR DESCRIPTION
This removes duplicate names from the `### Credits` section.

I could've ran the array through some `uniqBy` filter but I decided to replace the array with a `Set` instead since it gives us first class support for storing a list of unique values.