### PR TITLE
Add ‘--prefix-tag’ flag to prefix tag names

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -24,6 +24,7 @@ const pkg = require('../package')
 
 args
   .option('pre', 'Mark the release as prerelease')
+  .option(['t', 'prefix-tag'], 'Prefix tag name with "v"', false)
   .option('overwrite', 'If the release already exists, replace it')
 
 const flags = args.parse(process.argv)
@@ -61,7 +62,7 @@ const getReleaseURL = (release, edit = false) => {
   return edit ? htmlURL.replace('/tag/', '/edit/') : htmlURL
 }
 
-const createRelease = (tag_name, changelog, exists) => {
+const createRelease = (name, changelog, exists) => {
   const isPre = flags.pre ? 'pre' : ''
   handleSpinner.create(`Uploading ${isPre}release`)
 
@@ -71,7 +72,8 @@ const createRelease = (tag_name, changelog, exists) => {
   const body = {
     owner: repoDetails.user,
     repo: repoDetails.repo,
-    tag_name,
+    name,
+    tag_name: flags.prefixTag ? `v${name}` : name,
     body: changelog,
     draft: true,
     prerelease: flags.pre


### PR DESCRIPTION
Allow to prefix the release tag name with “v”, i.e. with a version “1.2.3”, `release -t` draft a release based on the “v1.2.3” tag. This is the format `npm version` uses by default.

To not affect the release name itself, it set the release “name” to the prefix-less version.

related to #30 and #35 