### PR TITLE
feat: drop requirement for release tag to exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 
 # logs
 npm-debug.log
+
+# coverage
+.nyc_output/
+coverage/

--- a/lib/pkg.js
+++ b/lib/pkg.js
@@ -1,0 +1,24 @@
+'use strict'
+
+// Native
+const fs = require('fs')
+
+exports.read = function () {
+  return readFile('./package.json', 'utf8').then(
+    json => JSON.parse(json)
+  ).catch(
+    err => Promise.reject(new Error(`Failed to package.json: ${err}`))
+  )
+}
+
+function readFile(fileName, option) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(fileName, option, (err, content) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve(content)
+      }
+    })
+  })
+}

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,0 +1,105 @@
+'use strict'
+
+// Packages
+const childProcess = require('child-process-promise')
+const semver = require('semver')
+const taggedVersions = require('tagged-versions')
+
+const HASH_REGEX = /^[0-9a-f]{7,40}$/
+
+/**
+ * Superset tagged-versions tag object with a hasPrefix property.
+ */
+class Tag {
+
+  constructor({version, hash, hasPrefix = false, date = null}) {
+    if (!version || !semver.valid(version)) {
+      throw new Error(`"${version}" is not a semantic version.`)
+    }
+
+    if (!hash || !HASH_REGEX.test(hash)) {
+      throw new Error(`"${hash}" is an invalid sha1 hash`)
+    }
+
+    this.version = version
+    this.date = date
+    this.hash = hash
+    this.hasPrefix = hasPrefix
+  }
+
+  get tag() {
+    const version = semver.clean(this.version)
+
+    return this.hasPrefix ? `v${version}` : version
+  }
+
+  /**
+   * Create a tag from either a Tag or a tagged-versions object.
+   *
+   * @param  {string}  options.tag    tag name
+   * @param  {string}  options.hash   commit hash
+   * @param  {Date}    options.date   commit date
+   * @param  {boolean} options.hasPrefix tag has a hasPrefix
+   * @return {Tag}
+   */
+  static from({version, hasPrefix, hash, date, tag}) {
+    if (tag) {
+      return new Tag({
+        hash,
+        date,
+        version: semver.clean(tag),
+        hasPrefix: tag.startsWith('v')
+      })
+    }
+
+    return new Tag({version, hasPrefix, hash, date})
+  }
+
+}
+
+exports.from = Tag.from
+
+/**
+ * Return the tags for the upcomming release and and the previous one.
+ *
+ * @param  {string} version Exact ver
+ * @return {Array<Tag>}
+ */
+exports.range = async function (version) {
+  if (!semver.valid(version)) {
+    throw new Error(`Invalid version: ${version}`)
+  }
+
+  const semRange = `<=${semver.clean(version)}`
+  const [hash, [first, second]] = await Promise.all([
+    getHeadHash(),
+    taggedVersions.getList(semRange)
+  ]).catch(
+    () => Promise.reject(new Error('Directory is not a Git repository.'))
+  )
+  const releaseIsTagged = Boolean(first) && first.version === version
+
+  if (!first || (releaseIsTagged && !second)) {
+    throw new Error('No initial release: the first release should be created manually.')
+  }
+
+  if (releaseIsTagged) {
+    return [Tag.from(first), Tag.from(second)]
+  }
+
+  const parent = Tag.from(first)
+  const release = Tag.from({version, hash, hasPrefix: parent.hasPrefix})
+
+  return [release, parent]
+}
+
+/**
+ * Query the local repo hash of HEAD.
+ *
+ * @return {string}
+ */
+async function getHeadHash() {
+  return childProcess.exec('git rev-parse HEAD').then(
+    result => result.stdout.trim()
+  )
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.1.2",
   "description": "Manage GitHub Releases from the command line",
   "scripts": {
-    "test": "xo",
+    "coverage": "nyc --reporter=lcov --reporter=text node --harmony-async-await node_modules/.bin/ava",
+    "lint": "xo",
+    "test": "npm run test:unit && xo",
+    "test:unit": "node --harmony-async-await node_modules/.bin/ava",
     "preinstall": "./bin/preinstall.js"
   },
   "files": [
@@ -41,6 +44,8 @@
   },
   "homepage": "https://github.com/zeit/release#readme",
   "devDependencies": {
+    "ava": "^0.17.0",
+    "nyc": "^10.0.0",
     "xo": "^0.17.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "ava": "^0.17.0",
     "nyc": "^10.0.0",
+    "sinon": "^1.17.7",
     "xo": "^0.17.1"
   },
   "dependencies": {
@@ -53,6 +54,7 @@
     "async-retry": "^0.2.1",
     "capitalize": "^1.0.0",
     "chalk": "^1.1.3",
+    "child-process-promise": "^2.2.0",
     "configstore": "^2.1.0",
     "git-commits": "^1.2.0",
     "git-repo-name": "^0.6.0",

--- a/test/pkg.js
+++ b/test/pkg.js
@@ -1,0 +1,27 @@
+// Packages
+import test from 'ava'
+
+// Ours
+import pkg from '../lib/pkg'
+
+const PWD = process.cwd()
+
+test.afterEach(() => {
+  process.chdir(PWD)
+})
+
+test.serial('load package in current working directory', async t => {
+  const ava = await pkgFrom('./node_modules/ava')
+
+  t.is(ava.name, 'ava')
+})
+
+test.serial('loading missing package should throws', t => {
+  t.throws(pkgFrom('./test'), /Failed to package\.json/)
+})
+
+async function pkgFrom(dir = '.') {
+  process.chdir(dir)
+
+  return pkg.read()
+}

--- a/test/tag.js
+++ b/test/tag.js
@@ -1,0 +1,178 @@
+// Packages
+import ps from 'child-process-promise'
+import sinon from 'sinon'
+import test from 'ava'
+import taggedVersions from 'tagged-versions'
+
+// Ours
+import tag from '../lib/tag'
+
+test('create Tag from version and hash', t => {
+  const version = '1.0.0'
+  const hash = '1234567'
+  const v1 = tag.from({version, hash})
+
+  t.deepEqual(v1.version, version)
+  t.deepEqual(v1.tag, version)
+  t.deepEqual(v1.hash, hash)
+})
+
+test('create Tag from tagged-versions tag', t => {
+  const vTag = {
+    tag: 'v1.1.2',
+    hash: '1234567',
+    date: new Date(),
+    version: '1.1.2'
+  }
+  const v1 = tag.from(vTag)
+
+  t.true(v1.hasPrefix)
+  t.deepEqual(v1.version, vTag.version)
+  t.deepEqual(v1.tag, vTag.tag)
+  t.deepEqual(v1.hash, vTag.hash)
+  t.deepEqual(v1.date, vTag.date)
+})
+
+test('create Tag with out version throws', t => {
+  t.throws(() => tag.from({hash: '1234567'}))
+})
+
+test('create Tag with  invalid version throws', t => {
+  t.throws(() => tag.from({version: '1.2', hash: '1234567'}))
+})
+
+test('create Tag with out a hash throws', t => {
+  t.throws(() => tag.from({version: '1.2.3'}))
+})
+
+test('create Tag with out invalid sha1 hash throws', t => {
+  const version = '1.2.3'
+  const withHash = hash => () => tag.from({version, hash})
+
+  t.throws(withHash('1'.repeat(6)), /invalid/, 'too short hash')
+  t.throws(withHash('1'.repeat(41)), /invalid/, 'too long hash')
+  t.throws(withHash('g'.repeat(6)), /invalid/, 'invalid char')
+
+  t.notThrows(withHash('1'.repeat(7)), 'long enough')
+  t.notThrows(withHash('1'.repeat(40)), 'max length')
+  t.notThrows(withHash('01234567890abcdef'), 'valid char')
+})
+
+test.serial('get range for tagged release', async t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList()
+
+  const range = await tag.range('1.1.2')
+
+  t.is(range.length, 2)
+  t.true(taggedVersions.getList.calledOnce)
+  t.true(taggedVersions.getList.calledWithExactly('<=1.1.2'))
+
+  const [release, parent] = range
+
+  t.is(release.version, '1.1.2')
+  t.is(parent.version, '1.1.1')
+})
+
+test.serial('get range for head commit', async t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList()
+
+  const range = await tag.range('1.1.3')
+
+  t.is(range.length, 2)
+  t.true(ps.exec.calledOnce)
+  t.true(ps.exec.calledWithExactly('git rev-parse HEAD'))
+
+  const [release, parent] = range
+
+  t.is(release.hash, head)
+  t.is(release.version, '1.1.3')
+  t.is(parent.version, '1.1.2')
+})
+
+test.serial('should throw when initial release is missing (1/2)', t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList([])
+
+  t.throws(tag.range('1.1.3'), /No initial release/)
+})
+
+test.serial('should throw when initial release is missing (2/2)', t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList(defaultList().slice(0, 1))
+
+  t.throws(tag.range('1.1.2'), /No initial release/)
+})
+
+test.serial('should throw on invalid version', t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList(defaultList().slice(0, 1))
+
+  t.throws(tag.range('foo'), /Invalid version/)
+})
+
+test.serial('should throw if the head commit cannot be query', t => {
+  mockExec(Promise.reject(new Error('fatal: Not a git repository (or any of the parent directories')))
+  mockVersionsList(defaultList().slice(0, 1))
+
+  t.throws(tag.range('1.1.3'), /Directory is not a Git repository/)
+})
+
+test.serial('should throw if tag list cannot be queried', t => {
+  const head = 'abcdef0'
+
+  mockExec({stdout: `${head}\n`})
+  mockVersionsList(Promise.reject(new Error('fatal: Not a git repository (or any of the parent directories')))
+
+  t.throws(tag.range('1.1.3'), /Directory is not a Git repository/)
+})
+
+test.afterEach('restore stub\'ed packages', () => {
+  [ps.exec, taggedVersions.getList].filter(
+    meth => typeof meth.restore === 'function'
+  ).forEach(
+    meth => meth.restore()
+  )
+})
+
+function mockExec(result) {
+  sinon.stub(ps, 'exec')
+  ps.exec.returns(Promise.resolve(result))
+}
+
+function mockVersionsList(list = defaultList()) {
+  sinon.stub(taggedVersions, 'getList')
+  taggedVersions.getList.returns(Promise.resolve(list))
+}
+
+function defaultList() {
+  return [{tag: '1.1.2',
+    hash: '1d73c2ec41e22a94438c68d72089c929dd7a07e2',
+    date: new Date('2017-01-07T21:06:22.000Z'),
+    version: '1.1.2'
+  }, {
+    tag: '1.1.1',
+    hash: 'd977a4a6c9878e643fa7fc43d959b8b77be14631',
+    date: new Date('2017-01-06T21:30:34.000Z'),
+    version: '1.1.1'
+  }, {tag: '1.1.0',
+    hash: '7b032c1581bccf09e93fa0e7dca8219237ea6867',
+    date: new Date('2017-01-06T21:16:22.000Z'),
+    version: '1.1.0'
+  }, {tag: '1.0.7',
+    hash: 'a019595f79b3a10315c0ce249738a2c580cedc11',
+    date: new Date('2017-01-03T11:24:30.000Z'),
+    version: '1.0.7'
+  }]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,0 @@
-// Packages
-import test from 'ava'
-
-test('placholder', t => t.pass())

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,4 @@
+// Packages
+import test from 'ava'
+
+test('placholder', t => t.pass())


### PR DESCRIPTION
Stop relying of an existing tag for the release to publish. The assumption are:

- that `package.json` holds the version to release;
- that previous release tag exist locally.

The new process is as follow:

1. `release` gets the version from `./package.json`;
1. find a tag for the version:
    - use the tag if it exists;
    - use HEAD if it doesn't exist;
1. find the tag for the previous release.

fix #41 #44 