### PR TITLE
chore: query only the required commits

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -154,20 +154,11 @@ const orderCommits = (commits, tags, exists) => {
 const collectChanges = (tags, exists = false) => {
   handleSpinner.create('Loading commit history')
 
-  getCommits().then(commits => {
+  getCommits(tags).then(commits => {
     const lastRelease = tags[1]
 
     if (!lastRelease) {
       handleSpinner.fail('The first release should be created manually.')
-    }
-
-    for (const commit of commits) {
-      const index = commits.indexOf(commit)
-
-      if (commit.hash === lastRelease.hash && index > 0) {
-        commits = commits.slice(0, index)
-        break
-      }
     }
 
     for (const commit of commits) {

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -7,11 +7,18 @@ const gitCommits = require('git-commits')
 // Ours
 const handleSpinner = require('./spinner')
 
-module.exports = () => new Promise(resolve => {
+module.exports = tags => new Promise((resolve, reject) => {
+  const [release, parent] = tags
+
+  if (!release || !parent || !parent.hash || !release.hash) {
+    reject(new Error('the first release should be created manually.'))
+  }
+
+  const rev = `${parent.hash}..${release.hash || 'HEAD'}`
   const repoPath = path.join(process.cwd(), '.git')
   const commits = []
 
-  gitCommits(repoPath).on('data', commit => {
+  gitCommits(repoPath, {rev}).on('data', commit => {
     commits.push(commit)
   }).on('error', () => {
     handleSpinner.fail('Not able to collect commits.')


### PR DESCRIPTION
The rev parameter `<parent-hash>..<release-hash>` requests all the commits up to `<release-hash`> but excluding all the commits up to `<parent-hash>`. It queries all relevant commits regardless of `<parent-hash>` and `<release-hash>` being in the same branch.

It limits the amount of commits to save in memory and avoid using commits newer than the tag hash.