### PR TITLE
chore: setup ava as test runner test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules
 
 # logs
 npm-debug.log
+
+# coverage
+.nyc_output/
+coverage/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.1.2",
   "description": "Manage GitHub Releases from the command line",
   "scripts": {
-    "test": "xo",
+    "coverage": "nyc --reporter=lcov --reporter=text node --harmony-async-await node_modules/.bin/ava",
+    "lint": "xo",
+    "test": "npm run test:unit && xo",
+    "test:unit": "node --harmony-async-await node_modules/.bin/ava",
     "preinstall": "./bin/preinstall.js"
   },
   "files": [
@@ -41,6 +44,8 @@
   },
   "homepage": "https://github.com/zeit/release#readme",
   "devDependencies": {
+    "ava": "^0.17.0",
+    "nyc": "^10.0.0",
     "xo": "^0.17.1"
   },
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,4 @@
+// Packages
+import test from 'ava'
+
+test('placholder', t => t.pass())


### PR DESCRIPTION
- Update `test` run-script command to run unit tests and xo.
- Add `test:unit` command to to run unit test only.
- Add `lint` command to only run xo.
- Add `coverage` command to only test with coverage, printing coverage and creating lcov report.