### PR TITLE
chore: Fix two lines before credits

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -51,7 +51,6 @@ module.exports = async (types, commits, changeTypes) => {
   }
 
   if (credits.size > 0) {
-    text += '\n'
     text += '### Credits \n\n'
     text += 'Huge thanks to '
 


### PR DESCRIPTION
Fixes #55. The lastChange variable creates a new line anyway. I haven't actually tested this but I am 99% sure it should work after looking through changelog.js. If anything breaks please say! 🤞

(BTW, first PR! 🎉)