### PR TITLE
fix: support maintenance branch and hotfix release

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,7 +178,7 @@ const checkReleaseStatus = async () => {
   let tags
 
   try {
-    tags = await taggedVersions.getList()
+    tags = await taggedVersions.getList({rev: 'HEAD'})
   } catch (err) {
     handleSpinner.fail('Directory is not a Git repository.')
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ const getReleaseURL = (release, edit = false) => {
   return edit ? htmlURL.replace('/tag/', '/edit/') : htmlURL
 }
 
-const createRelease = (tag_name, changelog, exists) => {
+const createRelease = (tag, changelog, exists) => {
   const isPre = flags.pre ? 'pre' : ''
   handleSpinner.create(`Uploading ${isPre}release`)
 
@@ -62,7 +62,7 @@ const createRelease = (tag_name, changelog, exists) => {
   const body = {
     owner: repoDetails.user,
     repo: repoDetails.repo,
-    tag_name,
+    tag_name: tag.tag,
     body: changelog,
     draft: true,
     prerelease: flags.pre
@@ -135,7 +135,7 @@ const orderCommits = (commits, tags, exists) => {
     const changelog = await createChangelog(grouped, commits, changeTypes)
 
     // Upload changelog to GitHub Releases
-    createRelease(tags[0].version, changelog, exists)
+    createRelease(tags[0], changelog, exists)
   })
 }
 
@@ -211,7 +211,7 @@ const checkReleaseStatus = async () => {
     let existingRelease = null
 
     for (const release of response) {
-      if (release.tag_name === tags[0].version) {
+      if (release.tag_name === tags[0].tag) {
         existingRelease = release
         break
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -63,6 +63,7 @@ const createRelease = (tag, changelog, exists) => {
     owner: repoDetails.user,
     repo: repoDetails.repo,
     tag_name: tag.tag,
+    target_commitish: tag.hash,
     body: changelog,
     draft: true,
     prerelease: flags.pre

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "request": "^2.79.0",
     "request-promise-native": "^1.0.3",
     "semver": "^5.3.0",
-    "tagged-versions": "^1.2.0",
+    "tagged-versions": "^1.3.0",
     "then-sleep": "^1.0.1",
     "trim": "0.0.1",
     "update-notifier": "^1.0.3"


### PR DESCRIPTION
fix: support maintenance branch and hotfix release

Get the latest tag from the current branch. Allow to checkout a tag to release it or to checkout any branch to release the latest tag from that branch

fix #61 