### PR TITLE
Adjust required Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "engines": {
-    "node": ">= 6.9.0"
+    "node": ">= 7.6.0"
   },
   "bugs": {
     "url": "https://github.com/zeit/release/issues"

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ When run, this command line interface automatically generates a new [GitHub Rele
 
 ## Usage
 
-Install the package from [npm](https://npmjs.com/release) (you'll need at least Node.js 8.0.0):
+Install the package from [npm](https://npmjs.com/release) (you'll need at least Node.js 7.6.0):
 
 ```bash
 npm install -g release


### PR DESCRIPTION
You state in the readme, that the required Node.js version is 8.0.0. This is not reflected in the "engines" property of the package.json, which states 6.9.0 is minimum version.
I assume the high version number is due to async/await which is enabled since Node.js v7.6. Therefore I adjusted the versions to 7.6.0. I tested the package with that version and it worked fine.
If v8.0.0 is still required let me know and I will adjust it.