### PR TITLE
Support for transferred repositories added

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -218,7 +218,7 @@ const checkReleaseStatus = coroutine(function*() {
   }
 
   githubConnection = yield connect()
-  repoDetails = yield getRepo()
+  repoDetails = yield getRepo(githubConnection)
 
   handleSpinner.create('Checking if release already exists')
 

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -6,7 +6,7 @@ const repoUser = require('git-username')
 // Ours
 const handleSpinner = require('./spinner')
 
-exports.getRepo = () =>
+exports.getRepo = githubConnection =>
   new Promise(resolve => {
     repoName((err, repo) => {
       if (err) {
@@ -15,9 +15,23 @@ exports.getRepo = () =>
       }
 
       const details = { repo }
-      details.user = repoUser()
 
-      resolve(details)
+      // If a repo has been transfered, the owner of the repo won't be the current user but an
+      // organization. By getting the repo, we can get the proper repo's owner, since repos.get
+      // handle the transfer, thing that repos.createRelease does not.
+      githubConnection.repos.get(
+        { owner: repoUser(), repo: details.repo },
+        (err, detailedRepo) => {
+          if (err) {
+            handleSpinner.fail('Could not determine GitHub repository.')
+            return
+          }
+
+          details.user = detailedRepo.data.owner.login
+
+          resolve(details)
+        }
+      )
     })
   })
 


### PR DESCRIPTION
To support transferred repositories, I added a query to `github.repos.get()`, which lets me get the correct owner of the repository.

I managed to publish a [release](https://github.com/Kilix/redux-select-entities/releases/tag/v3.1.0) for one of my own transferred package. I don't have many packages, so I can hardly make more exhaustive tests, but when running the command on non transferred repos, it seems to work).