### PR TITLE
Optionally include latest commit

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -44,6 +44,10 @@ args
   .option('overwrite', 'If the release already exists, replace it')
   .option('publish', 'Instead of creating a draft, publish the release')
   .option(['H', 'hook'], 'Specify a custom file to pipe releases through')
+  .option(
+    'include',
+    'Include the latest commit in the list of detected changes'
+  )
 
 const flags = args.parse(process.argv)
 
@@ -258,7 +262,7 @@ const collectChanges = async (tags, exists = false) => {
   let commits
 
   try {
-    commits = await getCommits(tags)
+    commits = await getCommits(tags, flags.include)
   } catch (err) {
     fail(err.message)
   }

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -61,7 +61,7 @@ const loadCommits = (repoPath, rev) => {
   })
 }
 
-module.exports = async tags => {
+module.exports = async (tags, includeLast) => {
   const [release, parent] = tags
 
   if (!release || !parent || !parent.hash || !release.hash) {
@@ -79,7 +79,9 @@ module.exports = async tags => {
   const latestIndex = all.indexOf(latest)
 
   // Remove the latest commit from the collection
-  all.splice(latestIndex, 1)
+  if (!includeLast) {
+    all.splice(latestIndex, 1)
+  }
 
   // Hand back the commits
   return { all, latest }


### PR DESCRIPTION
This PR adds a new CLI option that includes the latest commit when generating changelogs. This allows downstream users with git workflows that don't involve separate tag commits to maintain their desired history.

**Note:** I personally don't think `release` should attempt to [identify and ignore](https://github.com/zeit/release/blob/master/lib/commits.js#L77-L82) release reference commits at all. Is the rationale only to save the user from having to select "ignore" when iterating over these commits?

Resolves #93
  
  