### PR TITLE
Change github package to @octokit/rest

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,7 +7,7 @@ const open = require('open')
 const randomString = require('random-string')
 const retry = require('async-retry')
 const Storage = require('configstore')
-const GitHubAPI = require('github')
+const GitHubAPI = require('@octokit/rest')
 const sleep = require('then-sleep')
 
 // Utilities

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "xo": "0.18.2"
   },
   "dependencies": {
+    "@octokit/rest": "14.0.0",
     "@zeit/check-updates": "1.0.5",
     "args": "3.0.8",
     "async-retry": "1.1.4",
@@ -65,7 +66,6 @@
     "git-spawned-stream": "1.0.0",
     "git-state": "4.0.0",
     "git-username": "0.5.0",
-    "github": "13.1.0",
     "github-username": "4.1.0",
     "inquirer": "5.0.0",
     "node-version": "1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@octokit/rest@14.0.0":
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-14.0.0.tgz#29386f85d80ea3b3018b501bd7a98fa94c9e05fb"
+  dependencies:
+    before-after-hook "^1.1.0"
+    debug "^3.1.0"
+    dotenv "^4.0.0"
+    https-proxy-agent "^2.1.0"
+    is-stream "^1.1.0"
+    lodash "^4.17.4"
+    proxy-from-env "^1.0.0"
+    url-template "^2.0.8"
+
 "@zeit/check-updates@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@zeit/check-updates/-/check-updates-1.0.5.tgz#3ac40afe270a0cc646a279b629698a77ad4543c6"
@@ -179,6 +192,10 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
+
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
 
 boom@4.x.x:
   version "4.3.1"
@@ -1113,18 +1130,6 @@ github-username@4.1.0:
   resolved "https://registry.yarnpkg.com/github-username/-/github-username-4.1.0.tgz#cbe280041883206da4212ae9e4b5f169c30bf417"
   dependencies:
     gh-got "^6.0.0"
-
-github@13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-13.1.0.tgz#fc925950beebdff0cb0583197598b86f41bedaa4"
-  dependencies:
-    debug "^3.1.0"
-    dotenv "^4.0.0"
-    https-proxy-agent "^2.1.0"
-    is-stream "^1.1.0"
-    lodash "^4.17.4"
-    proxy-from-env "^1.0.0"
-    url-template "^2.0.8"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.2"


### PR DESCRIPTION
GitHub has renamed their package from `github` to `@octokit/rest`, per https://github.com/octokit/rest.js/releases/tag/v14.0.0, with no functional changes in the public API, so I have made the necessary changes for `release`. There should be no side effects, and the precommit checks passed. 😄