### PR TITLE
Only retrieve tags of the current branch

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -288,7 +288,6 @@ const checkReleaseStatus = async () => {
 
 	try {
 		const unordered = await getTags();
-
 		tags = unordered.sort((a, b) => new Date(b.date) - new Date(a.date));
 	} catch (err) {
 		fail('Directory is not a Git repository.');

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -2,7 +2,9 @@
 const semVer = require('semver');
 const taggedVersions = require('tagged-versions');
 
-module.exports = async (rev = 'HEAD') => {
+const defaultRev = 'HEAD --first-parent `git rev-parse --abbrev-ref HEAD`';
+
+module.exports = async (rev = defaultRev) => {
 	const [tags, latest] = await Promise.all([
 		taggedVersions.getList(),
 		taggedVersions.getLastVersion({rev})


### PR DESCRIPTION
When release commits are accidentally pushed to the wrong branches, this will prevent the package from breaking by only loading the tags/commits of the current branch.

This will be a major version bump, just to make sure that we're not breaking anyone's use case.