### PR TITLE
Shave off 16MB out of 17.3MB install size

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -54,16 +54,19 @@ const changeTypes = [
 	{
 		handle: 'major',
 		name: 'Major Change',
+		pluralName: 'Major Changes',
 		description: 'incompatible API change'
 	},
 	{
 		handle: 'minor',
 		name: 'Minor Change',
+		pluralName: 'Minor Changes',
 		description: 'backwards-compatible functionality'
 	},
 	{
 		handle: 'patch',
 		name: 'Patch',
+		pluralName: 'Patches',
 		description: 'backwards-compatible bug fix'
 	}
 ];

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -1,5 +1,4 @@
 // Packages
-const {plural} = require('pluralize');
 const getUsername = require('github-username');
 
 // Utilities
@@ -35,7 +34,7 @@ module.exports = async (types, commits, changeTypes, filteringWithHook) => {
 		const typeInfo = changeTypes.filter(item => item.handle === type)[0];
 
 		// Add heading
-		text += `### ${plural(typeInfo.name)} \n\n`;
+		text += `### ${typeInfo.pluralName} \n\n`;
 
 		// Find last change, in order to be able
 		// to add a newline after it

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "node-version": "1.1.3",
     "open": "0.0.5",
     "ora": "2.0.0",
-    "pluralize": "7.0.0",
     "random-string": "0.2.0",
     "request": "2.85.0",
     "request-promise-native": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1275,7 +1275,7 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pluralize@7.0.0, pluralize@^7.0.0:
+pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 


### PR DESCRIPTION
pluralize was only used on static text and always had the same outcome, hence we can just hardcode it and remove the dep weighting 16MB, leaving about 1.3MB