### PR TITLE
Add strict and previous-tag options

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -33,11 +33,12 @@ if (nodeVersion.major < 6) {
 	process.exit(1);
 }
 
-args
-	.option('pre', 'Mark the release as prerelease')
+args.option('pre', 'Mark the release as prerelease')
 	.option('overwrite', 'If the release already exists, replace it')
 	.option('publish', 'Instead of creating a draft, publish the release')
-	.option(['H', 'hook'], 'Specify a custom file to pipe releases through');
+	.option(['H', 'hook'], 'Specify a custom file to pipe releases through')
+	.option('strict', 'Search previous release only in current branch', false)
+	.option(['t', 'previous-tag'], 'Specify previous release', '');
 
 const flags = args.parse(process.argv);
 
@@ -290,7 +291,10 @@ const checkReleaseStatus = async () => {
 	let tags;
 
 	try {
-		const unordered = await getTags();
+		const unordered = await getTags({
+			strict: flags.strict,
+			previousTag: flags.previousTag
+		});
 		tags = unordered.sort((a, b) => new Date(b.date) - new Date(a.date));
 	} catch (err) {
 		fail('Directory is not a Git repository.');

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -4,9 +4,17 @@ const taggedVersions = require('tagged-versions');
 
 const defaultRev = 'HEAD --first-parent `git rev-parse --abbrev-ref HEAD`';
 
-module.exports = async (rev = defaultRev) => {
+const defaultOptions = {
+	rev: defaultRev,
+	strict: false,
+	previousTag: ''
+};
+
+module.exports = async (options = {}) => {
+	const {rev, strict, previousTag} = {...defaultOptions, ...options};
+
 	const [tags, latest] = await Promise.all([
-		taggedVersions.getList(),
+		taggedVersions.getList(strict ? {rev} : {}),
 		taggedVersions.getLastVersion({rev})
 	]);
 
@@ -14,8 +22,13 @@ module.exports = async (rev = defaultRev) => {
 		return [];
 	}
 
+	const isPreviousTag =
+		previousTag && previousTag.length > 0
+			? commitVersion => commitVersion === previousTag
+			: semVer.lt;
+
 	for (const commit of tags) {
-		if (semVer.lt(commit.version, latest.version)) {
+		if (isPreviousTag(commit.version, latest.version)) {
 			return [latest, commit];
 		}
 	}


### PR DESCRIPTION
Goal of this PR is to fix #127 

Adds to option:
```
-s, --strict        Search previous release only in current branch (disabled by default)
-t, --previous-tag  Specify previous release (defaults to "")
```