### PR TITLE
Automatically render link if opening browser failed

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -373,14 +373,14 @@ const checkReleaseStatus = async () => {
 	if (!flags.showUrl) {
 		try {
 			await open(releaseURL);
-			console.log(`${prefix}. Opened in browser...`);
+			console.error(`${prefix}. Opened in browser...`);
 
 			return;
 		// eslint-disable-next-line no-empty
 		} catch (err) {}
 	}
 
-	console.log(`${prefix}: ${releaseURL}`);
+	console.error(`${prefix}: ${releaseURL}`);
 	process.exit(1);
 };
 

--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -16,7 +16,7 @@ const getAuthor = async ({author}) => {
 	return username;
 };
 
-module.exports = async (types, commits, changeTypes, filteringWithHook) => {
+module.exports = async (types, commits, changeTypes, filteringWithHook, showURL) => {
 	let text = '';
 	const credits = new Set();
 
@@ -47,7 +47,8 @@ module.exports = async (types, commits, changeTypes, filteringWithHook) => {
 				changeTypes,
 				// Do not escape HTML from commit title
 				// if a custom hook is being used
-				!filteringWithHook
+				!filteringWithHook,
+				showURL
 			);
 
 			if (changeDetails.text) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -87,7 +87,7 @@ const loadToken = async () => {
 	return false;
 };
 
-const requestToken = async () => {
+const requestToken = async showURL => {
 	let authURL = 'https://github.com/login/oauth/authorize';
 
 	const state = randomString({
@@ -103,11 +103,17 @@ const requestToken = async () => {
 
 	authURL += `?${queryString.stringify(params)}`;
 
-	try {
-		await open(authURL);
-	} catch (err) {
-		console.error(`\nCould not open URL in browser. Please open the link: ${authURL}`);
+	if (!showURL) {
+		try {
+			await open(authURL);
+			console.log(`\nOpened authentication page in browser...`);
+
+			return;
+		// eslint-disable-next-line no-empty
+		} catch (err) {}
 	}
+
+	console.log(`\nPlease click this link to authenticate: ${authURL}`);
 
 	const token = await tokenAPI(state);
 	config.set('token', token);
@@ -115,7 +121,7 @@ const requestToken = async () => {
 	return token;
 };
 
-module.exports = async () => {
+module.exports = async showURL => {
 	let token = await loadToken();
 
 	if (!token) {
@@ -123,7 +129,7 @@ module.exports = async () => {
 		await sleep(100);
 
 		try {
-			token = await requestToken();
+			token = await requestToken(showURL);
 		} catch (err) {
 			handleSpinner.fail("Couldn't load token.");
 		}

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -103,17 +103,16 @@ const requestToken = async showURL => {
 
 	authURL += `?${queryString.stringify(params)}`;
 
-	if (!showURL) {
-		try {
-			await open(authURL);
-			console.log(`\nOpened authentication page in browser...`);
+	try {
+		if (showURL) {
+			throw new Error('No browser support');
+		}
 
-			return;
-		// eslint-disable-next-line no-empty
-		} catch (err) {}
+		await open(authURL);
+	} catch (err) {
+		global.spinner.stop();
+		console.log(`Please click this link to authenticate: ${authURL}`);
 	}
-
-	console.log(`\nPlease click this link to authenticate: ${authURL}`);
 
 	const token = await tokenAPI(state);
 	config.set('token', token);
@@ -125,13 +124,13 @@ module.exports = async showURL => {
 	let token = await loadToken();
 
 	if (!token) {
-		handleSpinner.create('Opening GitHub authentication page');
+		handleSpinner.create(showURL ? 'Retrieving authentication link' : 'Opening GitHub authentication page');
 		await sleep(100);
 
 		try {
 			token = await requestToken(showURL);
 		} catch (err) {
-			handleSpinner.fail("Couldn't load token.");
+			handleSpinner.fail('Could not load token.');
 		}
 	}
 

--- a/lib/pick-commit.js
+++ b/lib/pick-commit.js
@@ -7,8 +7,8 @@ const connect = require('./connect');
 const repo = require('./repo');
 const definitions = require('./definitions');
 
-const getPullRequest = async number => {
-	const github = await connect();
+const getPullRequest = async (number, showURL) => {
+	const github = await connect(showURL);
 	const repoDetails = await repo.getRepo(github);
 
 	const response = await github.pullRequests.get({
@@ -20,11 +20,11 @@ const getPullRequest = async number => {
 	return response.data;
 };
 
-const forPullRequest = async number => {
+const forPullRequest = async (number, showURL) => {
 	let data;
 
 	try {
-		data = await getPullRequest(number);
+		data = await getPullRequest(number, showURL);
 	} catch (err) {
 		return;
 	}
@@ -64,7 +64,7 @@ const cleanCommitTitle = (title, changeTypes, doEscapeHTML) => {
 	};
 };
 
-module.exports = async ({hash, message}, all, changeTypes, doEscapeHTML) => {
+module.exports = async ({hash, message}, all, changeTypes, doEscapeHTML, showURL) => {
 	const title = cleanCommitTitle(message, changeTypes, doEscapeHTML);
 	let credits = [];
 
@@ -74,7 +74,7 @@ module.exports = async ({hash, message}, all, changeTypes, doEscapeHTML) => {
 		const rawHash = hash.split('#')[1];
 
 		// Retrieve users that have collaborated on a change
-		const collaborators = await forPullRequest(rawHash);
+		const collaborators = await forPullRequest(rawHash, showURL);
 
 		if (collaborators) {
 			credits = credits.concat(collaborators);


### PR DESCRIPTION
This will ensure that – in addition to `--show-url` – we automatically render links if opening them in the browser failed (instead of throwing an error).

The change comes in especially handy for people working on a VM with no GUI.