### PR TITLE
Enable `--strict` by default and remove flag

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -37,7 +37,6 @@ args.option('pre', 'Mark the release as prerelease')
 	.option('overwrite', 'If the release already exists, replace it')
 	.option('publish', 'Instead of creating a draft, publish the release')
 	.option(['H', 'hook'], 'Specify a custom file to pipe releases through')
-	.option('strict', 'Search previous release only in current branch', false)
 	.option(['t', 'previous-tag'], 'Specify previous release', '')
 	.option(['u', 'show-url'], 'Show the release URL instead of opening it in the browser');
 
@@ -300,7 +299,6 @@ const checkReleaseStatus = async () => {
 
 	try {
 		const unordered = await getTags({
-			strict: flags.strict,
 			previousTag: flags.previousTag
 		});
 		tags = unordered.sort((a, b) => new Date(b.date) - new Date(a.date));

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -6,15 +6,14 @@ const defaultRev = 'HEAD --first-parent `git rev-parse --abbrev-ref HEAD`';
 
 const defaultOptions = {
 	rev: defaultRev,
-	strict: false,
 	previousTag: ''
 };
 
 module.exports = async (options = {}) => {
-	const {rev, strict, previousTag} = {...defaultOptions, ...options};
+	const {rev, previousTag} = {...defaultOptions, ...options};
 
 	const [tags, latest] = await Promise.all([
-		taggedVersions.getList(strict ? {rev} : {}),
+		taggedVersions.getList({rev}),
 		taggedVersions.getLastVersion({rev})
 	]);
 


### PR DESCRIPTION
This should've been enabled by default since the first iteration of `release`.

Sadly, we're pretty late now, so we need to do a major release.

You can read more about this change in the usage information displayed here: https://github.com/zeit/release/pull/144