### PR TITLE
Fix Stuck on "Opening GitHub authentication page"

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -127,7 +127,7 @@ const createRelease = async (tag, changelog, exists) => {
 
 	if (!showUrl) {
 		try {
-			await open(releaseURL);
+			open(releaseURL, {wait: false});
 			console.log(`\n${chalk.bold('Done!')} Opened release in browser...`);
 
 			return;
@@ -370,7 +370,7 @@ const checkReleaseStatus = async () => {
 
 	if (!flags.showUrl) {
 		try {
-			await open(releaseURL);
+			open(releaseURL, {wait: false});
 			console.error(`${prefix}. Opened in browser...`);
 
 			return;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -108,7 +108,7 @@ const requestToken = async showURL => {
 			throw new Error('No browser support');
 		}
 
-		await open(authURL);
+		open(authURL, {wait: false});
 	} catch (err) {
 		global.spinner.stop();
 		console.log(`Please click this link to authenticate: ${authURL}`);


### PR DESCRIPTION
Updated to not wait for `open` since it sometimes doesn't resolve until the browser is completely closed i.e. `cmd` + `q` on Mac

Fixes: #151 