### PR TITLE
Avoid adding and committing every file when releasing

### DIFF
--- a/lib/bump.js
+++ b/lib/bump.js
@@ -109,7 +109,9 @@ module.exports = async (type, preSuffix) => {
 	createSpinner('Creating release commit');
 
 	try {
-		await runGitCommand(`git add -A && git commit -a -m "${version}"`);
+		await runGitCommand(
+			`git add package.json package-lock.json && git commit -m "${version}"`
+		);
 	} catch (err) {
 		fail(err.message);
 	}


### PR DESCRIPTION
This is a change on the standard behaviour when releasing. 

Release by default adds all the files in your local repo and then commit everything, this might cause undesired files to be pushed, a security risk depending on the files exposed.

This change will only commit `package.json` and `package-lock.json` as part of the bump version stage.

Closes #162