### PR TITLE
X handle has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ Thanks a lot to [Daniel Chatfield](https://github.com/danielchatfield) for donat
 
 ## Author
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+Leo Lamprecht ([@leo](https://x.com/leo))


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.